### PR TITLE
Rename IETF_LEAP_SECOND_URL to IERS_LEAP_SECOND_URL_MIRROR

### DIFF
--- a/astropy_iers_data/__init__.py
+++ b/astropy_iers_data/__init__.py
@@ -14,7 +14,7 @@ __all__ = [
     "IERS_B_README",
     "IERS_LEAP_SECOND_FILE",
     "IERS_LEAP_SECOND_URL",
-    "IETF_LEAP_SECOND_URL"
+    "IERS_LEAP_SECOND_URL_MIRROR"
 ]
 
 DATA = pathlib.Path(__file__).resolve().parent / "data"
@@ -33,9 +33,7 @@ IERS_B_README = str(DATA / "ReadMe.eopc04")
 # LEAP SECONDS default file name, URL, and alternative format/URL
 IERS_LEAP_SECOND_FILE = str(DATA / "Leap_Second.dat")
 IERS_LEAP_SECOND_URL = "https://hpiers.obspm.fr/iers/bul/bulc/Leap_Second.dat"
-IETF_LEAP_SECOND_URL = "https://www.ietf.org/timezones/data/leap-seconds.list"
+IERS_LEAP_SECOND_URL_MIRROR = "https://www.ietf.org/timezones/data/leap-seconds.list"
 
 # TODO: should we include the 'IAU2000' pre-2023-style file?
 IERS_B_IAU2000_README = str(DATA / "ReadMe.eopc04_IAU2000")
-
-# TODO: rename IETF_LEAP_SECOND_URL to IERS_LEAP_SECOND_URL_MIRROR?


### PR DESCRIPTION
@taldcroft - you mentioned before that maybe not worth breaking backward-compatibility, but I was thinking, we can just give it the 'correct' name here and when we import it into astropy core we can rename it or add a backward-compatibility alias?