### PR TITLE
astropy dropped Python 3.9, dependabot for Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: ".github/workflows" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,6 +13,6 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - linux: py39-test
-        - macos: py310-test
-        - windows: py311-test
+        - linux: py310-test
+        - macos: py311-test
+        - windows: py312-test

--- a/.github/workflows/update_and_publish.yml
+++ b/.github/workflows/update_and_publish.yml
@@ -60,9 +60,9 @@ jobs:
     with:
       checkout_ref: ${{ needs.update.outputs.new_sha }}
       envs: |
-        - linux: py39-test
-        - macos: py310-test
-        - windows: py311-test
+        - linux: py310-test
+        - macos: py311-test
+        - windows: py312-test
 
   tag:
     name: Tag latest commit to main using calendar version


### PR DESCRIPTION
1. To put this back in sync with astropy after https://github.com/astropy/astropy/pull/15603
2. Add dependabot to auto-update Actions