### PR TITLE
Include automatically data files at build time

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ prune .github
 exclude .gitignore
 exclude update_data.sh
 exclude MANIFEST.in
-include astropy_iers_data/data/*.*
+include astropy_iers_data/data/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ prune .github
 exclude .gitignore
 exclude update_data.sh
 exclude MANIFEST.in
+include astropy_iers_data/data/*.*


### PR DESCRIPTION
Hi!

First of all, feel free to discard this if there is another way that should not belong in upstream to do so.

While checking the packaged package for ArchLinux I noticed the data files are not there, to build the package the `python -m build --wheel --no-isolation --skip-dependency-check` command is used and this doesn't bring data files along, which leads to exception at runtime.

This change will include all files under `astropy_iers_data/data/` in the build output