### PR TITLE
Tell setuptools_scm to not normalize version (fixes #17)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,4 @@
 
 [tool.setuptools_scm]
 write_to = "astropy_iers_data/_version.py"
+normalize = false


### PR DESCRIPTION
`setuptools_scm` normalizes versions by default. Among other things, it converts "00" into "0". With this PR `setuptools_scm` leaves the version as is.