### PR TITLE
Fix continuous integration

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,4 +15,4 @@ jobs:
       envs: |
         - linux: py310-test
         - macos: py311-test
-        - windows: py312-test
+        - windows: py312-test-astropydev

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,11 @@ isolated_build = true
 
 [testenv]
 changedir = .tmp/{envname}
+setenv =
+    astropydev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple
 deps =
-    git+https://github.com/astropy/astropy
+    !astropydev: astropy
+    astropydev: astropy>=0.0.dev0
 extras =
     test
 


### PR DESCRIPTION
This tests against astropy stable by default instead of astropy dev - the latter is now opt-in.

This should fix the CI but does not solve https://github.com/astropy/astropy-iers-data/issues/21

Blocks:

* #28 