### PR TITLE
chore(build): switch to hatch as build backend

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-# All files which are tracked by git and not explicitly excluded here are included by setuptools_scm
-prune .github
-exclude .gitignore
-exclude scripts/update_data.sh
-exclude MANIFEST.in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,46 +1,49 @@
 [build-system]
-  requires = [
-    "setuptools",
-    "setuptools_scm",
-    "wheel"
-  ]
-  build-backend = 'setuptools.build_meta'
-
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
 [project]
-  name = "astropy-iers-data"
-  dynamic = ["version"]
-  description = "IERS Earth Rotation and Leap Second tables for the astropy core package"
-  readme = "README.rst"
-  requires-python = ">=3.8"
-  license = {file = "LICENSE.rst"}
-  keywords = ["astropy", "data", "IERS"]
-  authors = [
-    {name = "Astropy Developers", email = "astropy.team@gmail.com"}
-  ]
-  classifiers = [
-    "Intended Audience :: Science/Research",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3",
-  ]
+name = "astropy-iers-data"
+dynamic = ["version"]
+description = "IERS Earth Rotation and Leap Second tables for the astropy core package"
+readme = "README.rst"
+requires-python = ">=3.8"
+license = {file = "LICENSE.rst"}
+keywords = ["astropy", "data", "IERS"]
+authors = [
+  {name = "Astropy Developers", email = "astropy.team@gmail.com"}
+]
+classifiers = [
+  "Intended Audience :: Science/Research",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: BSD License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+]
 
 [project.urls]
-  repository = "https://github.com/astropy/astropy-iers-data"
-  documentation = "https://github.com/astropy/astropy-iers-data/blob/main/README.rst"
+repository = "https://github.com/astropy/astropy-iers-data"
+documentation = "https://github.com/astropy/astropy-iers-data/blob/main/README.rst"
 
 [project.optional-dependencies]
-  test = [
-    "pytest",
-    "pytest-remotedata",
-    "hypothesis",
-  ]
-  docs = [
-    "pytest"
-  ]
+test = [
+  "pytest",
+  "pytest-remotedata",
+  "hypothesis",
+]
+docs = [
+  "pytest"
+]
 
+[tool.hatch.version]
+source = "vcs"
+scheme = "plain"
 
-[tool.setuptools_scm]
-write_to = "astropy_iers_data/_version.py"
-normalize = false
+[tool.hatch.build.hooks.vcs]
+version-file = "astropy_iers_data/_version.py"
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  ".github/",
+  "scripts/update_data.sh",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "IERS Earth Rotation and Leap Second tables for the astropy core package"
 readme = "README.rst"
 requires-python = ">=3.8"
-license = {file = "LICENSE.rst"}
+license-files = ["LICENSE.rst"]
 keywords = ["astropy", "data", "IERS"]
 authors = [
   {name = "Astropy Developers", email = "astropy.team@gmail.com"}


### PR DESCRIPTION
Reference: Fix #25 

Request for Review: @astrofrog 

contents of unzipped wheel

```bash
🐕 ❯ unzip dist/astropy_iers_data-0.1.dev183+g7bc8e1b.d20250515-py3-none-any.whl -d temp
Archive:  dist/astropy_iers_data-0.1.dev183+g7bc8e1b.d20250515-py3-none-any.whl
  inflating: temp/astropy_iers_data/__init__.py  
  inflating: temp/astropy_iers_data/_version.py  
  inflating: temp/astropy_iers_data/data/Leap_Second.dat  
  inflating: temp/astropy_iers_data/data/README.rst  
  inflating: temp/astropy_iers_data/data/ReadMe.eopc04  
  inflating: temp/astropy_iers_data/data/ReadMe.finals2000A  
  inflating: temp/astropy_iers_data/data/eopc04.1962-now  
  inflating: temp/astropy_iers_data/data/finals2000A.all  
  inflating: temp/astropy_iers_data/tests/__init__.py  
  inflating: temp/astropy_iers_data-0.1.dev183+g7bc8e1b.d20250515.dist-info/METADATA  
  inflating: temp/astropy_iers_data-0.1.dev183+g7bc8e1b.d20250515.dist-info/WHEEL  
  inflating: temp/astropy_iers_data-0.1.dev183+g7bc8e1b.d20250515.dist-info/licenses/LICENSE.rst  
  inflating: temp/astropy_iers_data-0.1.dev183+g7bc8e1b.d20250515.dist-info/RECORD  
```