### PR TITLE
Set up type checking with mypy

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -16,3 +16,9 @@ jobs:
         - linux: py310-test
         - macos: py311-test
         - windows: py312-test-astropydev
+
+  mypy:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@9f1fedda61294df4c004c05519a3fbf3b8e1f32f  # v2.3.1
+    with:
+      envs: |
+        - linux: mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ docs = [
   "pytest"
 ]
 
+[dependency-groups]
+mypy = ["mypy"]
+
 [tool.hatch.version]
 source = "vcs"
 scheme = "plain"
@@ -47,3 +50,7 @@ exclude = [
   ".github/",
   "scripts/update_data.sh",
 ]
+
+[tool.mypy]
+packages = ["astropy_iers_data"]
+strict = true

--- a/tox.ini
+++ b/tox.ini
@@ -27,3 +27,11 @@ extras = docs
 commands =
     pip freeze
     sphinx-build -W -b html . _build/html {posargs}
+
+
+[testenv:mypy]
+description = Type check with mypy
+deps =
+extras =
+dependency_groups = mypy
+commands = mypy


### PR DESCRIPTION
The first commit enables type checking with mypy. The `astropy_iers_data/_version.py` file that `setuptools_scm` generates when `astropy_iers_data` is installed is annotated and mypy can infer all the types everywhere else, so there is no need write any annotations. Adding basic mypy configuration is sufficient to enable type checking.

The second commit adds the [`py.typed` marker file](https://peps.python.org/pep-0561/#packaging-type-information) which declares support for type checking in downstream packages. Without this marker file type checking code that depends on `astropy_iers_data` causes typing errors:
```
error: Skipping analyzing "astropy_iers_data": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```

The third commit adds a tox environment and a CI job for type checking so that any typing errors in the future could be caught here before they cause problems downstream.