### PR TITLE
DEP: simplify and un-expose dev-only dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,14 +25,13 @@ classifiers = [
 repository = "https://github.com/astropy/astropy-iers-data"
 documentation = "https://github.com/astropy/astropy-iers-data/blob/main/README.rst"
 
-[project.optional-dependencies]
+[dependency-groups]
 test = [
-  "pytest",
-  "pytest-remotedata",
-  "hypothesis",
+  "pytest>=9.0.0",
 ]
-docs = [
-  "pytest"
+integration = [
+  {include-group = "test"},
+  "astropy[test]>=6.0.0",
 ]
 
 [tool.hatch.version]

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,10 @@ isolated_build = true
 changedir = .tmp/{envname}
 setenv =
     astropydev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple
-deps =
-    !astropydev: astropy
-    astropydev: astropy>=0.0.dev0
-extras =
-    test
+pip_pre =
+    astropydev: true
+dependency_groups =
+    integration
 
 commands =
     pip freeze


### PR DESCRIPTION
Most of these are never used anywhere, and pytest doesn't need to be exposed as an extra