### PR TITLE
DEP: drop support for CPython 3.8 and 3.9 (EOL)

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,8 +13,6 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@99401c364fa51c9c507d3cd6d272049278ac0b2c  # v2.4.0
     with:
       envs: |
-        - linux: py38-test
-        - linux: py39-test
         - linux: py310-test
         - linux: py311-test
         - linux: py312-test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "astropy-iers-data"
 dynamic = ["version"]
 description = "IERS Earth Rotation and Leap Second tables for the astropy core package"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = "BSD-3-Clause"
 license-files = ["LICENSE.rst"]
 keywords = ["astropy", "data", "IERS"]


### PR DESCRIPTION
close #56