### PR TITLE
BLD: use an include list instead of an exclude list for source dist artifacts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ scheme = "plain"
 version-file = "astropy_iers_data/_version.py"
 
 [tool.hatch.build.targets.sdist]
-exclude = [
-  ".github/",
-  "scripts/update_data.sh",
+only-include = [
+  "astropy_iers_data",
+  "tests",
 ]


### PR DESCRIPTION
This is much less likely to go out of sync, avoids undesired inclusions, and avoids "leaking" details about the source repo into distribution artifacts.