### PR TITLE
CLN: clean up an unmatched parentheis in a description field

### DIFF
--- a/astropy_iers_data/data/ReadMe.finals2000A
+++ b/astropy_iers_data/data/ReadMe.finals2000A
@@ -21,7 +21,7 @@ Byte-by-byte Description of file: *
    Bytes Format Units  Label  Explanations
 --------------------------------------------------------------------------------
   1-   2   I2    ---     year         To get true calendar year, add 1900 for 
-                                      MJD<=51543 or add 2000 for MJD>=51544)
+                                      MJD<=51543 or add 2000 for MJD>=51544
   3-   4   I2    ---     month
   5-   6   I2    ---     day          of month
   8-  15   F8.2    d     MJD          fractional Modified Julian Date (MJD UTC)


### PR DESCRIPTION
This was highlighted by my IDE when I took a look at the file's contents.
This mistake goes way back to #1, FWIW