### PR TITLE
BLD: Include tox.ini in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,4 +46,5 @@ version-file = "astropy_iers_data/_version.py"
 only-include = [
   "astropy_iers_data",
   "tests",
+  "tox.ini",
 ]


### PR DESCRIPTION
To fix #69 unless we agree on a different approach