### PR TITLE
REL: rewrite publishing workflow to use trusted publishers instead of a long lived API token

### DIFF
--- a/.github/workflows/update_and_publish.yml
+++ b/.github/workflows/update_and_publish.yml
@@ -94,13 +94,28 @@ jobs:
       - name: Create GitHub release
         run: gh release create ${{ steps.tag_name.outputs.version }} --generate-notes
 
-  publish:
+  build:
     name: Publish the release to PyPI
     needs: [update, tag]
     if: needs.update.outputs.changed
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@2835f0cacddf3f8de198db9afdb5354a5cebe0ef  # v2.6.3
     with:
       checkout_ref: ${{ needs.tag.outputs.new_tag }}
-      upload_to_pypi: true
-    secrets:
-      pypi_token: ${{ secrets.PYPI_TOKEN }}
+      # We use trusted publishing so the upload is handled in a separate job below
+      upload_to_pypi: false
+      save_artifacts: true
+
+  publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: [build]
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
Fix #19
This requires an intervention from a PyPI maintainer as well as a repo owner.
Double ping @astrofrog + @astrofrog :D